### PR TITLE
Allow to be used in modules

### DIFF
--- a/PicoKit.podspec
+++ b/PicoKit.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.default_subspec  = 'WebService'
   
   s.library = 'xml2'
-  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2',"CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES" }
 
   # Platform setup
   s.requires_arc = true


### PR DESCRIPTION
As it uses GData in a dependency and that one uses libxml you're not able to use it within a static library or a framework
